### PR TITLE
only enable languages swift and objc++ when building on macos. correc…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
-project(av-speech-in-noise LANGUAGES CXX OBJCXX Swift)
+project(av-speech-in-noise LANGUAGES CXX)
 
 include(FetchContent)
 

--- a/macos/CMakeLists.txt
+++ b/macos/CMakeLists.txt
@@ -43,6 +43,7 @@ function(add_macos_bundle target identifier output_name)
                ${CMAKE_CURRENT_SOURCE_DIR}/objective-c-bridge.h)
 endfunction()
 
+enable_language(OBJCXX Swift)
 option(AV_SPEECH_IN_NOISE_ENABLE_TOBII_EYETRACKING "Enables tobii eye tracking"
        OFF)
 if(${AV_SPEECH_IN_NOISE_ENABLE_TOBII_EYETRACKING})

--- a/test/Consonant.cpp
+++ b/test/Consonant.cpp
@@ -28,7 +28,7 @@ class ConsonantControlStub : public Control {
     auto consonant() -> std::string override { return consonant_; }
 
   private:
-    std::string consonant_;
+    std::string consonant_{"a"};
     Observer *listener_{};
 };
 


### PR DESCRIPTION
…t error in test